### PR TITLE
Add email format functions

### DIFF
--- a/config_backup.sh
+++ b/config_backup.sh
@@ -36,6 +36,6 @@ else # Send error message via Email.
     echo "-- End of failed config backup report --"
     echo "</pre>"
   ) >> "${EMAIL_CONTENT}"
-  sendmail -t < "${EMAIL_CONTENT}"
+  sendmail -i -t < "${EMAIL_CONTENT}"
   rm "${EMAIL_CONTENT}"
 fi

--- a/config_backup.sh
+++ b/config_backup.sh
@@ -3,18 +3,34 @@
 # Send a FreeNAS config backup via Email and also store it somewhere in a data pool.
 
 source user.conf && source global.conf
+source format_email.sh
 
 readonly EMAIL_SUBJECT="$(hostname) config backup"
-readonly EMAIL_CONTENT="/tmp/config_backup_error.eml"
-readonly TAR_FILE="/tmp/config_backup.tar.gz"
+readonly EMAIL_BODY="/tmp/config_backup.html"
+readonly EMAIL_CONTENT="/tmp/config_backup.eml"
+readonly TAR_FILE="/tmp/${BACKUP_FILE_NAME}.tar.gz"
 
 if [[ "$(sqlite3 /data/freenas-v1.db "pragma integrity_check;")" == "ok" ]]; then # Send via Email/Store config backup.
   cp /data/freenas-v1.db /tmp/"${BACKUP_FILE_NAME}".db
   sha256 /tmp/"${BACKUP_FILE_NAME}".db > /tmp/"${BACKUP_FILE_NAME}".db.sha256
   tar -czf "${TAR_FILE}" -C /tmp/ "${BACKUP_FILE_NAME}".db -C /tmp/ "${BACKUP_FILE_NAME}".db.sha256
-  # Add the backup config file inline because the mail utility of FreeNAS (as of version 11.1) is an old version that
-  # doesn't support the "-a" argument to attach files in MIME format.
-  uuencode "${TAR_FILE}" "${BACKUP_FILE_NAME}".tar.gz | mail -s "${EMAIL_SUBJECT}" "${EMAIL_ADDRESS}"
+  (
+    # Only specify monospace font to let Email client decide of the rest.
+    echo "<pre style=\"font-family:monospace\">"
+    echo "<b>Automatic backup of FreeNAS config succeded!</b>"
+    echo ""
+    echo "You will find a compressed archive attached."
+    echo ""
+    echo "-- End of config backup report --"
+    echo "</pre>"
+  ) > "${EMAIL_BODY}"
+  format_email_header "${EMAIL_SUBJECT}" "${EMAIL_ADDRESS}" > "${EMAIL_CONTENT}"
+  format_email_body "${EMAIL_BODY}" >> "${EMAIL_CONTENT}"
+  format_email_attachment "${TAR_FILE}" >> "${EMAIL_CONTENT}"
+  format_email_footer >> "${EMAIL_CONTENT}"
+  sendmail -i -t < "${EMAIL_CONTENT}"
+  rm "${EMAIL_BODY}"
+  rm "${EMAIL_CONTENT}"
   # Also store it somewhere that will be backed up by another service.
   if [[ "${BACKUP_FILE_PATH}" != "" ]]; then
     cp "${TAR_FILE}" "${BACKUP_FILE_PATH}"/"${BACKUP_FILE_NAME}".tar.gz
@@ -24,18 +40,19 @@ if [[ "$(sqlite3 /data/freenas-v1.db "pragma integrity_check;")" == "ok" ]]; the
   rm "${TAR_FILE}"
 else # Send error message via Email.
   (
-    echo "To: ${EMAIL_ADDRESS}"
-    echo "Subject: ${EMAIL_SUBJECT}"
-    echo "Content-Type: text/html"
-    echo -e "MIME-Version: 1.0\n" # Need a blank line between the headers and the body as per RFC 822.
     # Only specify monospace font to let Email client decide of the rest.
     echo "<pre style=\"font-family:monospace\">"
-    echo "<b>/!\ Automatic backup of FreeNAS config failed:</b>"
+    echo "<b>/!\ Automatic backup of FreeNAS config failed /!\</b>"
+    echo ""
     echo "The config file is corrupted, you should correct this problem as soon as possible."
     echo ""
-    echo "-- End of failed config backup report --"
+    echo "-- End of config backup report --"
     echo "</pre>"
-  ) >> "${EMAIL_CONTENT}"
+  ) > "${EMAIL_BODY}"
+  format_email_header "${EMAIL_SUBJECT}" "${EMAIL_ADDRESS}" > "${EMAIL_CONTENT}"
+  format_email_body "${EMAIL_BODY}" >> "${EMAIL_CONTENT}"
+  format_email_footer >> "${EMAIL_CONTENT}"
   sendmail -i -t < "${EMAIL_CONTENT}"
+  rm "${EMAIL_BODY}"
   rm "${EMAIL_CONTENT}"
 fi

--- a/format_email.sh
+++ b/format_email.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Bash functions to format an email to be sent by the FreeNAS 'sendmail' program.
+# FreeNAS 'sendmail' uses a "custom" mail sending program, written in Python by the FreeNAS team.
+# This Python program doesn't yet, as of FreeNAS 11.3-U2, support the Content-Type 'multipart/alternative'.
+
+# Usage: format_email_header "Email Subject" "Email Address" > /path/to/formated.eml
+format_email_header () {
+  email_boundary=$(head -c 24 /dev/urandom | base64)
+
+  echo "MIME-Version: 1.0"
+  echo "Subject: ${1}"
+  echo "To: ${2}"
+  echo "Content-Type: multipart/mixed; boundary=\"${email_boundary}\""
+  echo ""
+}
+
+# Usage: format_email_body /path/to/body.html >> /path/to/formated.eml
+format_email_body () {
+  echo "--${email_boundary}"
+  echo "Content-Type: text/html; charset=\"UTF-8\""
+  echo "Content-Transfer-Encoding: quoted-printable"
+  echo ""
+  cat "${1}" | perl -pe 'use MIME::QuotedPrint; $_=MIME::QuotedPrint::encode($_);'
+  echo ""
+}
+
+# Usage: format_email_attachment /path/to/attachment.ext >> /path/to/formated.eml
+format_email_attachment () {
+  echo "--${email_boundary}"
+  echo "Content-Type: text/plain; charset=\"US-ASCII\"; name=\"$(basename ${1})\""
+  echo "Content-Disposition: attachment; filename=\"$(basename ${1})\""
+  echo "Content-Transfer-Encoding: base64"
+  echo ""
+  cat "${1}" | base64
+}
+
+# Usage: format_email_footer >> /path/to/formated.eml
+format_email_footer () {
+  echo "--${email_boundary}--"
+}

--- a/smart_report.sh
+++ b/smart_report.sh
@@ -128,5 +128,5 @@ sed -i '' -e '/SMART Error Log Version/d' "${EMAIL_CONTENT}"
   echo "</pre>"
 ) >> "${EMAIL_CONTENT}"
 
-sendmail -t < "${EMAIL_CONTENT}"
+sendmail -i -t < "${EMAIL_CONTENT}"
 rm "${EMAIL_CONTENT}"

--- a/smart_report.sh
+++ b/smart_report.sh
@@ -3,20 +3,14 @@
 # Send a SMART status summary and detailed report of all SATA drives via Email.
 
 source user.conf && source global.conf
+source format_email.sh
 
 readonly EMAIL_SUBJECT="$(hostname) SMART status report"
+readonly EMAIL_BODY="/tmp/smart_report.html"
 readonly EMAIL_CONTENT="/tmp/smart_report.eml"
 
-# Set Email headers.
-(
-  echo "To: ${EMAIL_ADDRESS}"
-  echo "Subject: ${EMAIL_SUBJECT}"
-  echo "Content-Type: text/html"
-  echo -e "MIME-Version: 1.0\n" # Need a blank line between the headers and the body as per RFC 822.
-) > "${EMAIL_CONTENT}"
-
 # Only specify monospace font to let Email client decide of the rest.
-echo "<pre style=\"font-family:monospace\">" >> "${EMAIL_CONTENT}"
+echo "<pre style=\"font-family:monospace\">" > "${EMAIL_BODY}"
 
 # Print a summary table of the status of all drives.
 (
@@ -26,7 +20,7 @@ echo "<pre style=\"font-family:monospace\">" >> "${EMAIL_CONTENT}"
   echo "|      |               |    |On   |Stop |Retry|Sectors|Pending|Uncorrec|CRC   |Errors|Fly   |Timeout|Test|"
   echo "|      |               |    |Hours|Count|Count|       |Sectors|Sectors |Errors|      |Writes|Count  |Age |"
   echo "+------+---------------+----+-----+-----+-----+-------+-------+--------+------+------+------+-------+----+"
-) >> "${EMAIL_CONTENT}"
+) >> "${EMAIL_BODY}"
 for drive_label in ${SATA_DRIVES}; do
   # Ask smartctl to diplay the Seek_Error_Rate in raw hexadecimal so that we can extract the number of seek errors and
   # total number of seeks afterwards.
@@ -94,9 +88,9 @@ for drive_label in ${SATA_DRIVES}; do
   printf "|%-4s %1s|%-15s| %s |%5s|%5s|%5s|%7s|%7s|%8s|%6s|%6s|%6s|%7s|%4s|\n" "${drive_label}" "${ui_symbol}" \
     "${serial_number}" "${temperature}" "${power_on_hours}" "${start_stop_count}" "${spin_retry_count}" \
     "${realocated_sectors}" "${pending_sectors_count}" "${uncorrectable_sectors_count}" "${udma_crc_errors_count}" \
-    "${seek_errors}" "${high_fly_writes}" "${command_timeout}" "${test_age}" >> "${EMAIL_CONTENT}"
+    "${seek_errors}" "${high_fly_writes}" "${command_timeout}" "${test_age}" >> "${EMAIL_BODY}"
 done
-echo "+------+---------------+----+-----+-----+-----+-------+-------+--------+------+------+------+-------+----+" >> "${EMAIL_CONTENT}"
+echo "+------+---------------+----+-----+-----+-----+-------+-------+--------+------+------+------+-------+----+" >> "${EMAIL_BODY}"
 
 # Print a detailed SMART report for each drive.
 for drive_label in ${SATA_DRIVES}; do
@@ -111,22 +105,26 @@ for drive_label in ${SATA_DRIVES}; do
     smartctl -H -A -l error /dev/"${drive_label}"
     # Display the status of the last selftest.
     smartctl -l selftest /dev/"${drive_label}" | grep "# 1 \|Num" | cut -c6-
-  ) >> "${EMAIL_CONTENT}"
+  ) >> "${EMAIL_BODY}"
 done
 
 # Trimming unnecessary information from SMART detailed reports.
-sed -i '' -e '/smartctl 6.3/d' "${EMAIL_CONTENT}"
-sed -i '' -e '/Copyright/d' "${EMAIL_CONTENT}"
-sed -i '' -e '/=== START OF READ/d' "${EMAIL_CONTENT}"
-sed -i '' -e '/SMART Attributes Data/d' "${EMAIL_CONTENT}"
-sed -i '' -e '/Vendor Specific SMART/d' "${EMAIL_CONTENT}"
-sed -i '' -e '/SMART Error Log Version/d' "${EMAIL_CONTENT}"
+sed -i '' -e '/smartctl 6.3/d' "${EMAIL_BODY}"
+sed -i '' -e '/Copyright/d' "${EMAIL_BODY}"
+sed -i '' -e '/=== START OF READ/d' "${EMAIL_BODY}"
+sed -i '' -e '/SMART Attributes Data/d' "${EMAIL_BODY}"
+sed -i '' -e '/Vendor Specific SMART/d' "${EMAIL_BODY}"
+sed -i '' -e '/SMART Error Log Version/d' "${EMAIL_BODY}"
 
 (
   echo ""
   echo "-- End of SMART status report --"
   echo "</pre>"
-) >> "${EMAIL_CONTENT}"
+) >> "${EMAIL_BODY}"
 
+format_email_header "${EMAIL_SUBJECT}" "${EMAIL_ADDRESS}" > "${EMAIL_CONTENT}"
+format_email_body "${EMAIL_BODY}" >> "${EMAIL_CONTENT}"
+format_email_footer >> "${EMAIL_CONTENT}"
 sendmail -i -t < "${EMAIL_CONTENT}"
+rm "${EMAIL_BODY}"
 rm "${EMAIL_CONTENT}"

--- a/ups_report.sh
+++ b/ups_report.sh
@@ -259,5 +259,5 @@ done
   echo "</pre>"
 ) >> "${EMAIL_CONTENT}"
 
-sendmail -t < "${EMAIL_CONTENT}"
+sendmail -i -t < "${EMAIL_CONTENT}"
 rm "${EMAIL_CONTENT}"

--- a/zpool_report.sh
+++ b/zpool_report.sh
@@ -125,5 +125,5 @@ done
   echo "</pre>"
 ) >> "${EMAIL_CONTENT}"
 
-sendmail -t < "${EMAIL_CONTENT}"
+sendmail -i -t < "${EMAIL_CONTENT}"
 rm "${EMAIL_CONTENT}"


### PR DESCRIPTION
- Add the `-i` parameter to all `sendmail` calls which is recommended by the `sendmail` man page.
- Add a shell script containing functions to easily format an Email to be sent using FreeNAS "custom" `sendmail`.
- Fix email attachment in the `config_backup.sh` script.